### PR TITLE
change welcomeview to be compatible with mac look

### DIFF
--- a/audio_recorder/WelcomeView.swift
+++ b/audio_recorder/WelcomeView.swift
@@ -35,8 +35,8 @@ struct WelcomeView: View {
                     .background(LinearGradient(gradient: Gradient(colors: [Color.purple, Color.blue]),
                                                startPoint: .leading,
                                                endPoint: .trailing))
-                    .cornerRadius(15)
-                    .padding(.horizontal, 40)
+                    .cornerRadius(5)
+                    .padding(.horizontal, -10)
                     .shadow(color: Color.blue.opacity(0.4), radius: 10, x: 0, y: 5)
                 }
             }


### PR DESCRIPTION
Modified styling slightly so that audio recorder "start recording" button looks good on both mac and iOS

Previous mac look. A gap beyond the edges of the gradient can be seen:
<img width="335" alt="Welcome to" src="https://github.com/user-attachments/assets/3f08a4b8-fafc-40b5-94cb-d0e8401c6be7" />

Current mac look:
<img width="345" alt="Welcome to" src="https://github.com/user-attachments/assets/54e3b85b-788b-4372-83dd-e5764795a79a" />

Current iOS look (to confirm style changes did not break iOS appearance): 
<img width="400" alt="Welcome to" src="https://github.com/user-attachments/assets/75be3afd-d109-40e5-bc57-741bc7dd53e9" />
